### PR TITLE
Fixes use of strlcpy on glibc 2.38

### DIFF
--- a/src/proc_woodstock.c
+++ b/src/proc_woodstock.c
@@ -609,14 +609,16 @@ static void set_ext_flag (sim_t *sim, int ext_flag, bool value)
   case EXT_FLAG_ACT_KC:
   case EXT_FLAG_ACT_KD:
   case EXT_FLAG_ACT_KE:
-    uint8_t mask = 1 << (ext_flag - EXT_FLAG_ACT_KA);
-    if (value)
     {
-      act_reg->key_scanner_inputs |= mask;
-    }
-    else
-    {
-      act_reg->key_scanner_inputs &= ~mask;
+    	uint8_t mask = 1 << (ext_flag - EXT_FLAG_ACT_KA);
+    	if (value)
+    	{
+      		act_reg->key_scanner_inputs |= mask;
+    	}
+    	else
+    	{
+      		act_reg->key_scanner_inputs &= ~mask;
+    	}
     }
     break;
   case EXT_FLAG_ACT_KA_COND_S0:
@@ -624,11 +626,13 @@ static void set_ext_flag (sim_t *sim, int ext_flag, bool value)
   case EXT_FLAG_ACT_KC_COND_S0:
   case EXT_FLAG_ACT_KD_COND_S0:
   case EXT_FLAG_ACT_KE_COND_S0:
-    uint8_t mask2 = 1 << (ext_flag - EXT_FLAG_ACT_KA_COND_S0);
-    if (value)
-      act_reg->key_scanner_cond_s0_inputs |= mask2;
-    else
-      act_reg->key_scanner_cond_s0_inputs &= ~mask2;
+    {
+    	uint8_t mask2 = 1 << (ext_flag - EXT_FLAG_ACT_KA_COND_S0);
+    	if (value)
+      		act_reg->key_scanner_cond_s0_inputs |= mask2;
+    	else
+      		act_reg->key_scanner_cond_s0_inputs &= ~mask2;
+    }
     break;
   default:
     printf("ACT unknown ext flag %d\n", ext_flag);

--- a/src/util.c
+++ b/src/util.c
@@ -175,6 +175,7 @@ void realloc_strcpy (char **dest, char *src)
 }
 
 
+#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 28)
 // strlcpy will copy as much of src into dest as it can, up to one less than
 // the maximum length of dest specified by the argument l.  Unlike strncpy(),
 // strlcpy() will always leave dest NULL-terminated on return.
@@ -184,7 +185,7 @@ char *strlcpy (char *dest, const char *src, size_t l)
   dest [l - 1] = '\0';
   return dest;
 }
-
+#endif
 
 // strlncpy will copy up to n characters from src to dest, but not more than
 // one less than the maximum length of dest specified by the argument l.

--- a/src/util.c
+++ b/src/util.c
@@ -175,7 +175,7 @@ void realloc_strcpy (char **dest, char *src)
 }
 
 
-#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 28)
+#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 38)
 // strlcpy will copy as much of src into dest as it can, up to one less than
 // the maximum length of dest specified by the argument l.  Unlike strncpy(),
 // strlcpy() will always leave dest NULL-terminated on return.

--- a/src/util.h
+++ b/src/util.h
@@ -68,7 +68,7 @@ char *newstrn (char *orig, int max_len);
 void realloc_strcpy (char **dest, char *src);
 
 
-#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 28)
+#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 38)
 // strlcpy will copy as much of src into dest as it can, up to one less than
 // the maximum length of dest specified by the argument l.  Unlike strncpy(),
 // strlcpy() will always leave dest NULL-terminated on return.

--- a/src/util.h
+++ b/src/util.h
@@ -68,11 +68,12 @@ char *newstrn (char *orig, int max_len);
 void realloc_strcpy (char **dest, char *src);
 
 
+#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 28)
 // strlcpy will copy as much of src into dest as it can, up to one less than
 // the maximum length of dest specified by the argument l.  Unlike strncpy(),
 // strlcpy() will always leave dest NULL-terminated on return.
 char *strlcpy (char *dest, const char *src, size_t l);
-
+#endif
 
 // strlncpy will copy up to n characters from src to dest, but not more than
 // one less than the maximum length of dest specified by the argument l.


### PR DESCRIPTION
Fixes issue #13  adding a conditional to build the internal version of strlcpy