### PR TITLE
Fixing build on opensuse tumbleweed with the latest libxml

### DIFF
--- a/src/asm_cond_y.y
+++ b/src/asm_cond_y.y
@@ -29,6 +29,7 @@ MA 02111, USA.
 #include "symtab.h"
 #include "arch.h"
 #include "asm.h"
+#include "asm_cond.h"
 
 void asm_cond_error (char *s);
 %}

--- a/src/calcdef.c
+++ b/src/calcdef.c
@@ -23,6 +23,7 @@ MA 02111, USA.
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <libxml/SAX.h>
 #include <libxml/xmlwriter.h>

--- a/src/xmlutil.c
+++ b/src/xmlutil.c
@@ -25,6 +25,7 @@ MA 02111, USA.
 #include <string.h>
 
 #include <libxml/xmlwriter.h>
+#include <libxml/entities.h>
 
 #include "util.h"
 #include "xmlutil.h"


### PR DESCRIPTION
Adding missing includes required for latest versions libraries. Fix issue #17 