### PR TITLE
make calc chooser bigger

### DIFF
--- a/src/calc_chooser.c
+++ b/src/calc_chooser.c
@@ -69,6 +69,10 @@ char *calculator_chooser (char *path)
 		     gtk_hseparator_new ());
 
   file_chooser = gtk_file_chooser_widget_new (GTK_FILE_CHOOSER_ACTION_OPEN);
+  gtk_widget_set_size_request (file_chooser,
+                               460, // width
+                               300  // height
+                              );
 
   nui_kml_filter = gtk_file_filter_new ();
 


### PR DESCRIPTION
when called "nonpareil" allone there not enough room to see the calculator names (as filenames .nui)
did make the file_chooser bigger